### PR TITLE
Refactor

### DIFF
--- a/lib/check_for_wins.ex
+++ b/lib/check_for_wins.ex
@@ -3,13 +3,9 @@ defmodule CheckForWins do
     Enum.all?(row_data, fn symbol -> symbol == player_symbol end)
   end
 
-  def is_any_row_within_board_a_win?(row_data) do
-    wins_list = Enum.map(row_data, fn row -> is_row_a_win?(row, "X") || is_row_a_win?(row, "O") end)
-
-    cond do
-      Enum.member?(wins_list, true) -> true
-      true -> false
-    end
+  def is_any_row_within_board_a_win?(all_rows) do
+    Enum.map(all_rows, fn row -> is_row_a_win?(row, "X") || is_row_a_win?(row, "O") end)
+    |> Enum.member?(true)
   end
 
   def analyze(board) do
@@ -28,7 +24,7 @@ defmodule CheckForWins do
     end
   end
 
-  def handle_check_for_win(result, board, _current_player) do
+  def check_for_win(result, board, _current_player) do
     {result_code, result_value} = result
 
     case result_code do

--- a/lib/check_for_wins.ex
+++ b/lib/check_for_wins.ex
@@ -1,10 +1,10 @@
 defmodule CheckForWins do
-  def is_win?(row_data, player_symbol) do
+  def is_row_a_win?(row_data, player_symbol) do
     Enum.all?(row_data, fn symbol -> symbol == player_symbol end)
   end
 
-  def check_row(row_data) do
-    wins_list = Enum.map(row_data, fn row -> is_win?(row, "X") || is_win?(row, "O") end)
+  def is_any_row_within_board_a_win?(row_data) do
+    wins_list = Enum.map(row_data, fn row -> is_row_a_win?(row, "X") || is_row_a_win?(row, "O") end)
 
     cond do
       Enum.member?(wins_list, true) -> true
@@ -13,11 +13,11 @@ defmodule CheckForWins do
   end
 
   def analyze(board) do
-    horizontal = Board.convert_horizontal_to_row(board) |> check_row
+    horizontal = Board.convert_horizontal_to_row(board) |> is_any_row_within_board_a_win?
 
-    vertical = Board.convert_vertical_to_row(board) |> check_row
+    vertical = Board.convert_vertical_to_row(board) |> is_any_row_within_board_a_win?
 
-    diagonal = Board.convert_diagonal_to_row(board) |> check_row
+    diagonal = Board.convert_diagonal_to_row(board) |> is_any_row_within_board_a_win?
 
     board_has_win? = [horizontal, vertical, diagonal]
 
@@ -28,7 +28,7 @@ defmodule CheckForWins do
     end
   end
 
-  def handle_win_check(result, board, _current_player) do
+  def handle_check_for_win(result, board, _current_player) do
     {result_code, result_value} = result
 
     case result_code do

--- a/lib/process_input.ex
+++ b/lib/process_input.ex
@@ -1,19 +1,19 @@
 defmodule ProcessInput do
-  def transform_to_integer(string) do
+  defp transform_to_integer(string) do
     Integer.parse(string)
   end
 
-  def process_input(string, _board, _current_player) when is_tuple(string) do
+  defp process_input(string, _board, _current_player) when is_tuple(string) do
     string
     |> Tuple.to_list()
     |> Enum.fetch!(0)
   end
 
-  def process_input(_string, _board, _current_player) do
+  defp process_input(_string, _board, _current_player) do
     {:error, :invalid_input}
   end
 
-  def validate_input(result, board, _current_player) when is_integer(result) do
+  defp validate_input(result, board, _current_player) when is_integer(result) do
     cond do
       Board.is_a_empty_space(result, board) == true -> {:ok, result}
       result > 9 || result < 1 -> {:error, :invalid_input_range}
@@ -21,7 +21,7 @@ defmodule ProcessInput do
     end
   end
 
-  def validate_input(error, _board, _current_player) do
+  defp validate_input(error, _board, _current_player) do
     error
   end
 

--- a/lib/tic_tac_toe.ex
+++ b/lib/tic_tac_toe.ex
@@ -47,7 +47,7 @@ defmodule TicTacToe do
     GameIO.get_player_input(current_player, prompt)
     |> ProcessInput.handle_input(board, current_player)
     |> Board.handle_board_update(board, current_player)
-    |> CheckForWins.handle_check_for_win(board, current_player)
+    |> CheckForWins.check_for_win(board, current_player)
     |> handle_check_for_win_result(board, current_player)
   end
 end

--- a/lib/tic_tac_toe.ex
+++ b/lib/tic_tac_toe.ex
@@ -8,7 +8,7 @@ defmodule TicTacToe do
     end
   end
 
-  def handle_win_check_result(result, initial_board, current_player) do
+  def handle_check_for_win_result(result, initial_board, current_player) do
     {status, message, updated_board} = result
 
     cond do
@@ -47,7 +47,7 @@ defmodule TicTacToe do
     GameIO.get_player_input(current_player, prompt)
     |> ProcessInput.handle_input(board, current_player)
     |> Board.handle_board_update(board, current_player)
-    |> CheckForWins.handle_win_check(board, current_player)
-    |> handle_win_check_result(board, current_player)
+    |> CheckForWins.handle_check_for_win(board, current_player)
+    |> handle_check_for_win_result(board, current_player)
   end
 end

--- a/test/board_test.exs
+++ b/test/board_test.exs
@@ -49,7 +49,7 @@ defmodule Board_Test do
   end
 
   test "[has_empty_spaces] Returns False if board is filled." do
-    initial_board = %{
+    has_no_empty_spaces_board = %{
       1 => "X",
       2 => "O",
       3 => "X",
@@ -61,11 +61,11 @@ defmodule Board_Test do
       9 => "X"
     }
 
-    assert Board.has_empty_spaces?(initial_board) == false
+    assert Board.has_empty_spaces?(has_no_empty_spaces_board) == false
   end
 
   test "[has_empty_spaces] Returns True if board has more spaces to play." do
-    initial_board = %{
+    has_empty_spaces_board = %{
       1 => "X",
       2 => "O",
       3 => "X",
@@ -77,11 +77,11 @@ defmodule Board_Test do
       9 => " "
     }
 
-    assert Board.has_empty_spaces?(initial_board) == true
+    assert Board.has_empty_spaces?(has_empty_spaces_board) == true
   end
 
   test "[is_a_empty_space] Returns false if position has player symbol." do
-    initial_board = %{
+    space_is_already_taken_board = %{
       1 => "X",
       2 => " ",
       3 => " ",
@@ -93,11 +93,11 @@ defmodule Board_Test do
       9 => " "
     }
 
-    assert Board.is_a_empty_space(1, initial_board) == false
+    assert Board.is_a_empty_space(1, space_is_already_taken_board) == false
   end
 
   test "[is_a_empty_space] Returns true if position has no player symbol." do
-    initial_board = %{
+    space_is_not_taken_board = %{
       1 => "X",
       2 => " ",
       3 => " ",
@@ -109,7 +109,7 @@ defmodule Board_Test do
       9 => " "
     }
 
-    assert Board.is_a_empty_space(2, initial_board) == true
+    assert Board.is_a_empty_space(2, space_is_not_taken_board) == true
   end
 
 

--- a/test/check_for_wins_test.exs
+++ b/test/check_for_wins_test.exs
@@ -180,7 +180,7 @@ defmodule Check_For_Wins_Test do
     assert CheckForWins.analyze(no_diagonal_win_board) == {:ok, :no_win, no_diagonal_win_board}
   end
 
-  test "[handle_win_check] Winning board is passed to analyze and results in ok tuple" do
+  test "[handle_check_for_win] Winning board is passed to analyze and results in ok tuple" do
     winning_board = %{
       1 => "X",
       2 => "X",
@@ -193,11 +193,11 @@ defmodule Check_For_Wins_Test do
       9 => " "
     }
 
-    assert CheckForWins.handle_win_check({:ok, winning_board}, winning_board, "X") ==
+    assert CheckForWins.handle_check_for_win({:ok, winning_board}, winning_board, "X") ==
              {:ok, :wins_game, winning_board}
   end
 
-  test "[handle_win_check] Non winning board results in error tuple" do
+  test "[handle_check_for_win] Non winning board results in :no_win tuple" do
     non_winning_board = %{
       1 => "X",
       2 => "X",
@@ -210,11 +210,11 @@ defmodule Check_For_Wins_Test do
       9 => " "
     }
 
-    assert CheckForWins.handle_win_check({:ok, non_winning_board}, non_winning_board, "X") ==
+    assert CheckForWins.handle_check_for_win({:ok, non_winning_board}, non_winning_board, "X") ==
              {:ok, :no_win, non_winning_board}
   end
 
-  test "[handle_win_check] Error passed to this function results in error tuple" do
+  test "[handle_check_for_win] Error tuple passed to this function results in another error tuple" do
     board_with_error = %{
       1 => "X",
       2 => "X",
@@ -227,25 +227,25 @@ defmodule Check_For_Wins_Test do
       9 => " "
     }
 
-    assert CheckForWins.handle_win_check({:error, :invalid_input}, board_with_error, "X") ==
+    assert CheckForWins.handle_check_for_win({:error, :invalid_input}, board_with_error, "X") ==
              {:error, :invalid_input, board_with_error}
   end
 
-  test "[is_win?] Returns true if every symbol in list matches current player symbol" do
-    assert CheckForWins.is_win?(["X", "X", "X"], "X") == true
+  test "[is_row_a_win?] Returns true if every symbol in list matches current player symbol" do
+    assert CheckForWins.is_row_a_win?(["X", "X", "X"], "X") == true
   end
 
-  test "[is_win?] Returns false if every symbol in list does not match current player symbol" do
-    assert CheckForWins.is_win?(["X", "X", "X"], "O") == false
+  test "[is_row_a_win?] Returns false if every symbol in list does not match current player symbol" do
+    assert CheckForWins.is_row_a_win?(["X", "X", "X"], "O") == false
   end
 
-  test "[check_row] Checks each row in data and returns true if there is at least a single winning row" do
-    row = [["X", "O", "X"], ["O", "X", "O"], ["X", "X", "X"]]
-    assert CheckForWins.check_row(row) == true
+  test "[is_any_row_within_board_a_win?] Checks each row in data and returns true if there is at least a single winning row" do
+    board_data_split_by_row = [["X", "O", "X"], ["O", "X", "O"], ["X", "X", "X"]]
+    assert CheckForWins.is_any_row_within_board_a_win?(board_data_split_by_row) == true
   end
 
-  test "[check_row] Checks each row in data and returns false if there is no winning row" do
-    row = [["X", "O", "X"], ["O", "X", "O"], ["X", "O", "X"]]
-    assert CheckForWins.check_row(row) == false
+  test "[is_any_row_within_board_a_win?] Checks each row in data and returns false if there is no winning row" do
+    board_data_split_by_row = [["X", "O", "X"], ["O", "X", "O"], ["X", "O", "X"]]
+    assert CheckForWins.is_any_row_within_board_a_win?(board_data_split_by_row) == false
   end
 end

--- a/test/check_for_wins_test.exs
+++ b/test/check_for_wins_test.exs
@@ -5,7 +5,7 @@ defmodule Check_For_Wins_Test do
   doctest CheckForWins
 
   test "[analyze][Horizontal Wins] Row 1 - Wins if they have 3 matching horizontal symbols" do
-    initial_board = %{
+    horizontal_win_board = %{
       1 => "X",
       2 => "X",
       3 => "X",
@@ -17,11 +17,11 @@ defmodule Check_For_Wins_Test do
       9 => " "
     }
 
-    assert CheckForWins.analyze(initial_board) == {:ok, :wins_game, initial_board}
+    assert CheckForWins.analyze(horizontal_win_board) == {:ok, :wins_game, horizontal_win_board}
   end
 
   test "[analyze][Horizontal Wins] Row 2 - Wins if they have 3 matching horizontal symbols" do
-    initial_board = %{
+    horizontal_win_board = %{
       1 => " ",
       2 => " ",
       3 => " ",
@@ -33,11 +33,11 @@ defmodule Check_For_Wins_Test do
       9 => " "
     }
 
-    assert CheckForWins.analyze(initial_board) == {:ok, :wins_game, initial_board}
+    assert CheckForWins.analyze(horizontal_win_board) == {:ok, :wins_game, horizontal_win_board}
   end
 
   test "[analyze][Horizontal Wins] No wins if no adjacent matches in row" do
-    initial_board = %{
+    no_horizontal_win_board = %{
       1 => " ",
       2 => "X",
       3 => "X",
@@ -49,11 +49,11 @@ defmodule Check_For_Wins_Test do
       9 => " "
     }
 
-    assert CheckForWins.analyze(initial_board) == {:ok, :no_win, initial_board}
+    assert CheckForWins.analyze(no_horizontal_win_board) == {:ok, :no_win, no_horizontal_win_board}
   end
 
   test "[analyze][Horizontal Wins] Row 3 - No wins if there are 3 in a row from both players" do
-    initial_board = %{
+    no_horizontal_win_board = %{
       1 => " ",
       2 => " ",
       3 => " ",
@@ -65,11 +65,11 @@ defmodule Check_For_Wins_Test do
       9 => "O"
     }
 
-    assert CheckForWins.analyze(initial_board) == {:ok, :no_win, initial_board}
+    assert CheckForWins.analyze(no_horizontal_win_board) == {:ok, :no_win, no_horizontal_win_board}
   end
 
   test "[analyze][Vertical Wins] Column 1 - Wins if there are 3 matching vertical" do
-    initial_board = %{
+    vertical_win_board = %{
       1 => "X",
       2 => " ",
       3 => " ",
@@ -81,11 +81,11 @@ defmodule Check_For_Wins_Test do
       9 => " "
     }
 
-    assert CheckForWins.analyze(initial_board) == {:ok, :wins_game, initial_board}
+    assert CheckForWins.analyze(vertical_win_board) == {:ok, :wins_game, vertical_win_board}
   end
 
   test "[analyze][Vertical Wins] Column 2 - Wins if there are 3 matching vertical" do
-    initial_board = %{
+    vertical_win_board = %{
       1 => "X",
       2 => "O",
       3 => " ",
@@ -97,11 +97,11 @@ defmodule Check_For_Wins_Test do
       9 => " "
     }
 
-    assert CheckForWins.analyze(initial_board) == {:ok, :wins_game, initial_board}
+    assert CheckForWins.analyze(vertical_win_board) == {:ok, :wins_game, vertical_win_board}
   end
 
   test "[analyze][Vertical Wins] Column 3 - Wins if there are 3 matching vertical" do
-    initial_board = %{
+    vertical_win_board = %{
       1 => " ",
       2 => " ",
       3 => "X",
@@ -113,11 +113,11 @@ defmodule Check_For_Wins_Test do
       9 => "X"
     }
 
-    assert CheckForWins.analyze(initial_board) == {:ok, :wins_game, initial_board}
+    assert CheckForWins.analyze(vertical_win_board) == {:ok, :wins_game, vertical_win_board}
   end
 
   test "[analyze][Vertical Wins] Does not win if there are non-matching" do
-    initial_board = %{
+    no_vertical_win_board = %{
       1 => " ",
       2 => " ",
       3 => "X",
@@ -129,11 +129,11 @@ defmodule Check_For_Wins_Test do
       9 => "X"
     }
 
-    assert CheckForWins.analyze(initial_board) == {:ok, :no_win, initial_board}
+    assert CheckForWins.analyze(no_vertical_win_board) == {:ok, :no_win, no_vertical_win_board}
   end
 
   test "[analyze][Diagonal Wins] Diagonal 1 - 3 Matching Diagonal wins 1,5,9" do
-    initial_board = %{
+    diagonal_win_board = %{
       1 => "X",
       2 => " ",
       3 => " ",
@@ -145,11 +145,11 @@ defmodule Check_For_Wins_Test do
       9 => "X"
     }
 
-    assert CheckForWins.analyze(initial_board) == {:ok, :wins_game, initial_board}
+    assert CheckForWins.analyze(diagonal_win_board) == {:ok, :wins_game, diagonal_win_board}
   end
 
   test "[analyze][Diagonal Wins] Diagon 2 - 3 Matching Diagonal wins 3,5,7" do
-    initial_board = %{
+    diagonal_win_board = %{
       1 => " ",
       2 => " ",
       3 => "O",
@@ -161,11 +161,11 @@ defmodule Check_For_Wins_Test do
       9 => " "
     }
 
-    assert CheckForWins.analyze(initial_board) == {:ok, :wins_game, initial_board}
+    assert CheckForWins.analyze(diagonal_win_board) == {:ok, :wins_game, diagonal_win_board}
   end
 
   test "[analyze][Diagonal Wins] Non-Matching Diagonal does not win 3,5,7" do
-    initial_board = %{
+    no_diagonal_win_board = %{
       1 => " ",
       2 => " ",
       3 => "O",
@@ -177,11 +177,11 @@ defmodule Check_For_Wins_Test do
       9 => " "
     }
 
-    assert CheckForWins.analyze(initial_board) == {:ok, :no_win, initial_board}
+    assert CheckForWins.analyze(no_diagonal_win_board) == {:ok, :no_win, no_diagonal_win_board}
   end
 
   test "[handle_win_check] Winning board is passed to analyze and results in ok tuple" do
-    initial_board = %{
+    winning_board = %{
       1 => "X",
       2 => "X",
       3 => "X",
@@ -193,12 +193,12 @@ defmodule Check_For_Wins_Test do
       9 => " "
     }
 
-    assert CheckForWins.handle_win_check({:ok, initial_board}, initial_board, "X") ==
-             {:ok, :wins_game, initial_board}
+    assert CheckForWins.handle_win_check({:ok, winning_board}, winning_board, "X") ==
+             {:ok, :wins_game, winning_board}
   end
 
   test "[handle_win_check] Non winning board results in error tuple" do
-    initial_board = %{
+    non_winning_board = %{
       1 => "X",
       2 => "X",
       3 => "O",
@@ -210,12 +210,12 @@ defmodule Check_For_Wins_Test do
       9 => " "
     }
 
-    assert CheckForWins.handle_win_check({:ok, initial_board}, initial_board, "X") ==
-             {:ok, :no_win, initial_board}
+    assert CheckForWins.handle_win_check({:ok, non_winning_board}, non_winning_board, "X") ==
+             {:ok, :no_win, non_winning_board}
   end
 
   test "[handle_win_check] Error passed to this function results in error tuple" do
-    initial_board = %{
+    board_with_error = %{
       1 => "X",
       2 => "X",
       3 => "O",
@@ -227,8 +227,8 @@ defmodule Check_For_Wins_Test do
       9 => " "
     }
 
-    assert CheckForWins.handle_win_check({:error, :invalid_input}, initial_board, "X") ==
-             {:error, :invalid_input, initial_board}
+    assert CheckForWins.handle_win_check({:error, :invalid_input}, board_with_error, "X") ==
+             {:error, :invalid_input, board_with_error}
   end
 
   test "[is_win?] Returns true if every symbol in list matches current player symbol" do

--- a/test/check_for_wins_test.exs
+++ b/test/check_for_wins_test.exs
@@ -180,7 +180,7 @@ defmodule Check_For_Wins_Test do
     assert CheckForWins.analyze(no_diagonal_win_board) == {:ok, :no_win, no_diagonal_win_board}
   end
 
-  test "[handle_check_for_win] Winning board is passed to analyze and results in ok tuple" do
+  test "[check_for_win] Winning board is passed to analyze and results in ok tuple" do
     winning_board = %{
       1 => "X",
       2 => "X",
@@ -193,11 +193,11 @@ defmodule Check_For_Wins_Test do
       9 => " "
     }
 
-    assert CheckForWins.handle_check_for_win({:ok, winning_board}, winning_board, "X") ==
+    assert CheckForWins.check_for_win({:ok, winning_board}, winning_board, "X") ==
              {:ok, :wins_game, winning_board}
   end
 
-  test "[handle_check_for_win] Non winning board results in :no_win tuple" do
+  test "[check_for_win] Non winning board results in :no_win tuple" do
     non_winning_board = %{
       1 => "X",
       2 => "X",
@@ -210,11 +210,11 @@ defmodule Check_For_Wins_Test do
       9 => " "
     }
 
-    assert CheckForWins.handle_check_for_win({:ok, non_winning_board}, non_winning_board, "X") ==
+    assert CheckForWins.check_for_win({:ok, non_winning_board}, non_winning_board, "X") ==
              {:ok, :no_win, non_winning_board}
   end
 
-  test "[handle_check_for_win] Error tuple passed to this function results in another error tuple" do
+  test "[check_for_win] Error tuple passed to this function results in another error tuple" do
     board_with_error = %{
       1 => "X",
       2 => "X",
@@ -227,7 +227,7 @@ defmodule Check_For_Wins_Test do
       9 => " "
     }
 
-    assert CheckForWins.handle_check_for_win({:error, :invalid_input}, board_with_error, "X") ==
+    assert CheckForWins.check_for_win({:error, :invalid_input}, board_with_error, "X") ==
              {:error, :invalid_input, board_with_error}
   end
 

--- a/test/game_IO_test.exs
+++ b/test/game_IO_test.exs
@@ -35,4 +35,38 @@ defmodule Game_Output_Test do
   test "[get_message] Gets default message on nil param" do
     assert GameIO.get_message(nil) == ~s(Select a numbered spot: )
   end
+
+  test "[print_win] Prints win message" do
+    initial_board = %{
+      1 => " ",
+      2 => " ",
+      3 => " ",
+      4 => " ",
+      5 => " ",
+      6 => " ",
+      7 => " ",
+      8 => " ",
+      9 => " "
+    }
+    assert capture_io(fn -> GameIO.print_win(initial_board, "X") end) ==
+             GameIO.get_board(initial_board) <> "\n"
+             <>  "Player X - " <> GameIO.get_message(:wins_game) <> "\n"
+  end
+
+  test "[print_tie] Prints tie message" do
+    initial_board = %{
+      1 => " ",
+      2 => " ",
+      3 => " ",
+      4 => " ",
+      5 => " ",
+      6 => " ",
+      7 => " ",
+      8 => " ",
+      9 => " "
+    }
+    assert capture_io(fn -> GameIO.print_tie(initial_board) end) ==
+             GameIO.get_board(initial_board) <> "\n"
+             <> GameIO.get_message(:game_is_a_tie) <> "\n"
+  end
 end

--- a/test/game_IO_test.exs
+++ b/test/game_IO_test.exs
@@ -4,7 +4,7 @@ defmodule Game_Output_Test do
   doctest GameIO
 
   test "[print_board] Prints 3x3 board to CL" do
-    initial_board = %{
+    initial_3x3_board = %{
       1 => " ",
       2 => " ",
       3 => " ",
@@ -16,8 +16,8 @@ defmodule Game_Output_Test do
       9 => " "
     }
 
-    assert capture_io(fn -> GameIO.print_board(initial_board) end) ==
-             GameIO.get_board(initial_board) <> "\n"
+    assert capture_io(fn -> GameIO.print_board(initial_3x3_board) end) ==
+             GameIO.get_board(initial_3x3_board) <> "\n"
   end
 
   test "[get_other_player_symbol] Toggles player symbols from X -> O" do
@@ -37,7 +37,7 @@ defmodule Game_Output_Test do
   end
 
   test "[print_win] Prints win message" do
-    initial_board = %{
+    winning_board = %{
       1 => " ",
       2 => " ",
       3 => " ",
@@ -48,13 +48,13 @@ defmodule Game_Output_Test do
       8 => " ",
       9 => " "
     }
-    assert capture_io(fn -> GameIO.print_win(initial_board, "X") end) ==
-             GameIO.get_board(initial_board) <> "\n"
+    assert capture_io(fn -> GameIO.print_win(winning_board, "X") end) ==
+             GameIO.get_board(winning_board) <> "\n"
              <>  "Player X - " <> GameIO.get_message(:wins_game) <> "\n"
   end
 
   test "[print_tie] Prints tie message" do
-    initial_board = %{
+    tie_board = %{
       1 => " ",
       2 => " ",
       3 => " ",
@@ -65,8 +65,8 @@ defmodule Game_Output_Test do
       8 => " ",
       9 => " "
     }
-    assert capture_io(fn -> GameIO.print_tie(initial_board) end) ==
-             GameIO.get_board(initial_board) <> "\n"
+    assert capture_io(fn -> GameIO.print_tie(tie_board) end) ==
+             GameIO.get_board(tie_board) <> "\n"
              <> GameIO.get_message(:game_is_a_tie) <> "\n"
   end
 end

--- a/test/process_input_test.exs
+++ b/test/process_input_test.exs
@@ -37,7 +37,7 @@ defmodule Process_Input_Test do
   end
 
   test "[handle_input] On overlapping input, returns error tuple with correct error message" do
-    initial_board = %{
+    board_with_error_input = %{
       1 => "X",
       2 => " ",
       3 => " ",
@@ -49,12 +49,12 @@ defmodule Process_Input_Test do
       9 => " "
     }
 
-    assert ProcessInput.handle_input("1", initial_board, "O") == {:error, :duplicate_input}
+    assert ProcessInput.handle_input("1", board_with_error_input, "O") == {:error, :duplicate_input}
   end
 
 
   test "[handle_input] After non-number input, returns error tuple with correct error message" do
-    initial_board = %{
+    board_with_error_input = %{
       1 => "X",
       2 => " ",
       3 => " ",
@@ -66,11 +66,11 @@ defmodule Process_Input_Test do
       9 => " "
     }
 
-    assert ProcessInput.handle_input("string", initial_board, "X") == {:error, :invalid_input}
+    assert ProcessInput.handle_input("string", board_with_error_input, "X") == {:error, :invalid_input}
   end
 
   test "[handle_input] Inputting a number NOT 1-9, returns a error tuple with correct error message" do
-    initial_board = %{
+    board_with_error_input = %{
       1 => " ",
       2 => " ",
       3 => " ",
@@ -82,7 +82,7 @@ defmodule Process_Input_Test do
       9 => " "
     }
 
-    assert ProcessInput.handle_input("10", initial_board, "X") == {:error, :invalid_input_range}
+    assert ProcessInput.handle_input("10", board_with_error_input, "X") == {:error, :invalid_input_range}
   end
 
 end

--- a/test/tic_tac_toe_test.exs
+++ b/test/tic_tac_toe_test.exs
@@ -6,7 +6,7 @@ defmodule Tic_Tac_Toe_Test do
   doctest ProcessInput
 
   test "[handle_win_check_result] Tie result will end the game and output Tie message." do
-    initial_board = %{
+    tie_board = %{
       1 => "X",
       2 => "X",
       3 => "O",
@@ -20,16 +20,16 @@ defmodule Tic_Tac_Toe_Test do
 
     assert capture_io(fn ->
              TicTacToe.handle_win_check_result(
-               {:error, :game_is_a_tie, initial_board},
-               initial_board,
+               {:error, :game_is_a_tie, tie_board},
+               tie_board,
                "O"
              )
            end) ==
-            capture_io(fn -> GameIO.print_tie(initial_board) end)
+            capture_io(fn -> GameIO.print_tie(tie_board) end)
   end
 
   test "[handle_win_check_result] Winning result will end the game and output Win Game message" do
-    initial_board = %{
+    winning_board = %{
       1 => "X",
       2 => "X",
       3 => "X",
@@ -43,12 +43,12 @@ defmodule Tic_Tac_Toe_Test do
 
     assert capture_io(fn ->
              TicTacToe.handle_win_check_result(
-               {:ok, :wins_game, initial_board},
-               initial_board,
+               {:ok, :wins_game, winning_board},
+               winning_board,
                "X"
              )
            end) ==
-           capture_io(fn -> GameIO.print_win(initial_board, "X") end)
+           capture_io(fn -> GameIO.print_win(winning_board, "X") end)
   end
 
   # test "No win continues the game" do

--- a/test/tic_tac_toe_test.exs
+++ b/test/tic_tac_toe_test.exs
@@ -25,8 +25,7 @@ defmodule Tic_Tac_Toe_Test do
                "O"
              )
            end) ==
-             GameIO.get_board(initial_board) <> "\n" <>
-             GameIO.get_message(:game_is_a_tie) <> "\n"
+            capture_io(fn -> GameIO.print_tie(initial_board) end)
   end
 
   test "[handle_win_check_result] Winning result will end the game and output Win Game message" do
@@ -49,9 +48,7 @@ defmodule Tic_Tac_Toe_Test do
                "X"
              )
            end) ==
-             GameIO.get_board(initial_board) <>
-               "\n" <>
-               "Player X - " <> GameIO.get_message(:wins_game) <> "\n"
+           capture_io(fn -> GameIO.print_win(initial_board, "X") end)
   end
 
   # test "No win continues the game" do

--- a/test/tic_tac_toe_test.exs
+++ b/test/tic_tac_toe_test.exs
@@ -5,7 +5,7 @@ defmodule Tic_Tac_Toe_Test do
   doctest GameIO
   doctest ProcessInput
 
-  test "[handle_win_check_result] Tie result will end the game and output Tie message." do
+  test "[handle_check_for_win_result] Tie result will end the game and output Tie message." do
     tie_board = %{
       1 => "X",
       2 => "X",
@@ -19,7 +19,7 @@ defmodule Tic_Tac_Toe_Test do
     }
 
     assert capture_io(fn ->
-             TicTacToe.handle_win_check_result(
+             TicTacToe.handle_check_for_win_result(
                {:error, :game_is_a_tie, tie_board},
                tie_board,
                "O"
@@ -28,7 +28,7 @@ defmodule Tic_Tac_Toe_Test do
             capture_io(fn -> GameIO.print_tie(tie_board) end)
   end
 
-  test "[handle_win_check_result] Winning result will end the game and output Win Game message" do
+  test "[handle_check_for_win_result] Winning result will end the game and output Win Game message" do
     winning_board = %{
       1 => "X",
       2 => "X",
@@ -42,7 +42,7 @@ defmodule Tic_Tac_Toe_Test do
     }
 
     assert capture_io(fn ->
-             TicTacToe.handle_win_check_result(
+             TicTacToe.handle_check_for_win_result(
                {:ok, :wins_game, winning_board},
                winning_board,
                "X"
@@ -76,7 +76,7 @@ defmodule Tic_Tac_Toe_Test do
   #     9 => " "
   #   }
 
-  #   assert TicTacToe.handle_win_check_result(
+  #   assert TicTacToe.handle_check_for_win_result(
   #            {:error, :no_win, updated_board},
   #            initial_board,
   #            "X"

--- a/test/tic_tac_toe_test.exs
+++ b/test/tic_tac_toe_test.exs
@@ -50,36 +50,4 @@ defmodule Tic_Tac_Toe_Test do
            end) ==
            capture_io(fn -> GameIO.print_win(winning_board, "X") end)
   end
-
-  # test "No win continues the game" do
-  #   initial_board = %{
-  #     1 => "X",
-  #     2 => "O",
-  #     3 => "X",
-  #     4 => " ",
-  #     5 => " ",
-  #     6 => " ",
-  #     7 => " ",
-  #     8 => " ",
-  #     9 => " "
-  #   }
-
-  #   updated_board = %{
-  #     1 => "X",
-  #     2 => "O",
-  #     3 => "X",
-  #     4 => "O",
-  #     5 => " ",
-  #     6 => " ",
-  #     7 => " ",
-  #     8 => " ",
-  #     9 => " "
-  #   }
-
-  #   assert TicTacToe.handle_check_for_win_result(
-  #            {:error, :no_win, updated_board},
-  #            initial_board,
-  #            "X"
-  #          ) !== {:error}
-  # end
 end


### PR DESCRIPTION
### Closes Epic #12 
### Closes #7  #8  #9 #10  #11 

# Things Done
- Set functions that aren't used outside of ProcessInput as `defp`.
- Add test units for the `print_win` and `print_tie` functions. Results of it were hard coded in the TicTacToe tests, so used capture_io to tie it back directly to `print_win` and `print_tie` functions.
- Refactor CheckForWins by renaming functions
- Renamed board data variables in test units for clarity. 

# Consider how it would change if players were to choose their own marks:
- On initial game start, game needs to get player symbol (defaults to X) and then the first space on the board.
- On second user input, game would need to get player symbol (defaults to Y) before getting their board space input.
- These 2 symbols should be saved as values in "get_other_player_symbol" to toggle between players correctly.
- These 2 symbols would be passed through the TicTacToe.play() function
- Would need to refactor the `is_any_row_within_board_a_win?` function to check for the specific players symbol, instead of a hardcoded "X" and "O".